### PR TITLE
Update title to always include site name

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <title>{{ site.title }}{% if page.title %} | {{ page.title }}{% endif %}</title>
     <link rel="icon" type="image/png" href="/assets/images/WIR_spanner_transparent.png" />
     {% if page.tagline %}<meta name="description" content="{{ page.tagline }}">{% endif %} 
     {% if page.keywords %}<meta name="keywords" content="{{ page.keywords }}">{% endif %}


### PR DESCRIPTION
Changes the site title to be `Women in Robotics | <page name>` instead of `<page name>`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/womeninrobotics/womeninrobotics.github.io/25)
<!-- Reviewable:end -->
