### PR TITLE
Update build step to include bundle install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,6 @@ jobs:
           cache-version: 3
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build
+        run: bundle install && bundle exec jekyll build
       - name: Test with htmlproofer
         run: .github/scripts/htmlproofer/entrypoint.sh


### PR DESCRIPTION
Attempting fix, workflows failing with
```
 bundler: command not found: jekyll
6:06:55 PM: Install missing gem executables with `bundle install`
6:06:55 PM: ​
6:06:55 PM: "build.command" failed  
```